### PR TITLE
Set energy to 0 in case of instant BB

### DIFF
--- a/Python/Scripts/classes/features.py
+++ b/Python/Scripts/classes/features.py
@@ -470,6 +470,7 @@ class Features(Navigation, Inputs):
             self.click(ncon.NGU_PLUSX, ncon.NGU_PLUSY + target * 35)
 
         for target in targets:
+            energy = 0
             for x in range(198):
                 color = self.get_pixel_color(ncon.NGU_BAR_MINX + x,
                                              ncon.NGU_BAR_Y +


### PR DESCRIPTION
If first NGU is instantly BBed, energy is never set, causes an error. Setting it explicitly before the pixel check will make the function more robust.