### PR TITLE
fixed a wrong number parse when comma separators are present

### DIFF
--- a/classes/inputs.py
+++ b/classes/inputs.py
@@ -345,6 +345,11 @@ class Inputs:
     def remove_spaces(s :str) -> str:
         """Remove all spaces from string."""
         return "".join(s.split(" "))
+
+    @staticmethod
+    def remove_number_separators(s :str) -> str:
+        """Remove all separators from number."""
+        return "".join(s.split(","))
     
     @staticmethod
     def remove_letters(s :str) -> str:
@@ -354,7 +359,7 @@ class Inputs:
     @staticmethod
     def get_numbers(s :str) -> Iterable[int]:
         """Finds all numbers in a string"""
-        s = Inputs.remove_spaces(s)
+        s = Inputs.remove_number_separators(Inputs.remove_spaces(s))
         match = re.findall(r"(\d+(\.\d+E\+\d+)?)", s)
         nums = [int(float(x[0])) for x in match]
         return nums

--- a/classes/inputs.py
+++ b/classes/inputs.py
@@ -359,7 +359,8 @@ class Inputs:
     @staticmethod
     def get_numbers(s :str) -> Iterable[int]:
         """Finds all numbers in a string"""
-        s = Inputs.remove_number_separators(Inputs.remove_spaces(s))
+        s = Inputs.remove_spaces(s)
+        s = Inputs.remove_number_separators(s)
         match = re.findall(r"(\d+(\.\d+E\+\d+)?)", s)
         nums = [int(float(x[0])) for x in match]
         return nums


### PR DESCRIPTION
So I was having wrong numbers parsed from my magic bars, because the regex was only retrieving the first part of the number (anything after the first comma was not parsed).

A quick fix was to replace every commas with empty char. Don't know if it could cause other problems but it looks fine to me.